### PR TITLE
Support of all endpoints and simplified API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,65 @@
 
 This library allows for programmatic interactions with the [Metis infrastructure](https://metis.science).
 
-
 ## Installation
 
 `pip install metis_client`
 
+## Usage
+
+There are two client flavors - asyncronous `asyncio` client and simplified synchronous client.
+
+### Asynchronous client
+
+There is a asynchronous client `MetisAPIAsync`. Example of usage:
+
+```python
+from metis_client import MetisAPIAsync, MetisTokenAuth
+
+async def main():
+    async with MetisAPIAsync(API_URL, auth=MetisTokenAuth("admin@test.com")) as client:
+        print(await client.v0.auth.whoami())
+        data = await client.v0.datasources.create(content)
+        calc = await client.v0.calculations.create(data.id)
+        print(calc)
+
+        # There is also a low level interface
+        from metis_client.models import MetisDataSourcesEventModel, MetisCalculationsEventModel
+        async with client.stream.subscribe() as sub:
+            req = await client.v0.datasources.create_event(content)
+            async for msg in sub:
+                if (
+                    MetisDataSourcesEventModel.guard(msg)
+                    and msg.request_id == req.request_id
+                ):
+                    answer = msg
+                    break
+            data_id = sorted(answer.data, key=lambda x: x.created_at)[-1].id
+            req = await client.v0.calculations.create_event(data_id)
+            async for msg in sub:
+                if (
+                    MetisCalculationsEventModel.guard(msg)
+                    and msg.request_id == req.request_id
+                ):
+                    answer = msg
+                    break
+            print(answer)
+```
+
+See `examples` directory for more examples.
+
+### Synchronous client
+
+There is a synchronous client `MetisAPI`. Example of usage:
+
+```python
+from metis_client import MetisAPI, MetisTokenAuth
+
+client = MetisAPI(API_URL, auth=MetisTokenAuth("admin@test.com"))
+data = client.v0.datasources.create(content)
+calc = client.v0.calculations.create(data.id)
+print(calc)
+```
 
 ## License
 

--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import signal
+import sys
+
+from anyio import CancelScope, create_task_group, open_signal_receiver, run
+from yarl import URL
+
+from metis_client import MetisAPIAsync, MetisTokenAuth
+from metis_client.models import MetisCalculationModel, MetisDataSourceModel
+
+API_URL = URL("http://localhost:3000")
+
+try:
+    content = open(sys.argv[1]).read()
+except IndexError:
+    content = """{"attributes":{"immutable_id":42, "species":[{"chemical_symbols":
+["Au"]}],"cartesian_site_positions":[[0,0,0]],"lattice_vectors":[[0,2,2],[2,0,2],[2,2,0]]}}"""
+
+
+async def signal_handler(scope: CancelScope):
+    with open_signal_receiver(signal.SIGINT, signal.SIGTERM) as signals:
+        async for signum in signals:
+            if signum == signal.SIGINT:
+                print("Ctrl+C pressed!")
+            else:
+                print("Terminated!")
+
+            scope.cancel()
+            return
+
+
+async def job():
+    async with MetisAPIAsync(API_URL, auth=MetisTokenAuth("admin@test.com")) as client:
+        print(await client.v0.auth.whoami())
+        data = await client.v0.datasources.create(content)
+        if not isinstance(data, MetisDataSourceModel):
+            return
+
+        calc = await client.v0.calculations.create(data.id)
+        if not isinstance(calc, MetisCalculationModel):
+            return
+        print(calc)
+        print("=" * 100 + "Test passed")
+
+
+async def main():
+    async with create_task_group() as tg:
+        tg.start_soon(signal_handler, tg.cancel_scope)
+        await job()
+        tg.cancel_scope.cancel()
+
+
+run(main)

--- a/examples/example_async_low_level.py
+++ b/examples/example_async_low_level.py
@@ -1,30 +1,22 @@
 #!/usr/bin/env python3
 
-import sys
 import signal
+import sys
 
-import aiohttp
-from anyio import CancelScope, run, open_signal_receiver, create_task_group
+from anyio import CancelScope, create_task_group, open_signal_receiver, run
 from yarl import URL
 
-from metis_client import MetisAPI, MetisLocalUserAuth, MetisTokenAuth
-from metis_client.models.event import MetisDataSourcesEventModel, MetisCalculationsEventModel
-
+from metis_client import MetisAPIAsync, MetisTokenAuth
+from metis_client.models import MetisCalculationsEventModel, MetisDataSourcesEventModel
 
 API_URL = URL("http://localhost:3000")
 
-try: content = open(sys.argv[1]).read()
-except IndexError: content = """{"attributes":{"immutable_id":42, "species":[{"chemical_symbols":
+try:
+    content = open(sys.argv[1]).read()
+except IndexError:
+    content = """{"attributes":{"immutable_id":42, "species":[{"chemical_symbols":
 ["Au"]}],"cartesian_site_positions":[[0,0,0]],"lattice_vectors":[[0,2,2],[2,0,2],[2,2,0]]}}"""
 
-async def on_request_start(session, trace_config_ctx, params):
-    print("Starting request")
-    #print(params)
-
-async def on_request_end(session, trace_config_ctx, params):
-    print("Ending request")
-    #print(params)
-    #print(await params.response.text())
 
 async def signal_handler(scope: CancelScope):
     with open_signal_receiver(signal.SIGINT, signal.SIGTERM) as signals:
@@ -37,46 +29,41 @@ async def signal_handler(scope: CancelScope):
             scope.cancel()
             return
 
-trace_config = aiohttp.TraceConfig()
-trace_config.on_request_start.append(on_request_start)
-trace_config.on_request_end.append(on_request_end)
 
 async def job():
-    async with MetisAPI(
-        API_URL,
-        MetisTokenAuth("admin@test.com"),
-        trace_configs=[trace_config],
-    ) as client:
+    async with MetisAPIAsync(API_URL, auth=MetisTokenAuth("admin@test.com")) as client:
+        print(await client.v0.auth.whoami())
         async with client.stream.subscribe() as sub:
-            await client.v0.ping()
-            print(await client.v0.auth.whoami())
-            req = await client.v0.datasources.create(content)
+            req = await client.v0.datasources.create_event(content)
             answer = None
             async for msg in sub:
                 if (
-                    isinstance(msg, MetisDataSourcesEventModel)
+                    MetisDataSourcesEventModel.guard(msg)
                     and msg.request_id == req.request_id
                 ):
                     answer = msg
                     break
             if not answer or not answer.data:
                 return None
+
             data_id = sorted(answer.data, key=lambda x: x.created_at)[-1].id
-            req = await client.v0.calculations.create(data_id)
+            req = await client.v0.calculations.create_event(data_id)
             async for msg in sub:
                 if (
-                    isinstance(msg, MetisCalculationsEventModel)
+                    MetisCalculationsEventModel.guard(msg)
                     and msg.request_id == req.request_id
                 ):
                     answer = msg
                     break
             print(answer)
-            print('=' * 100 + 'Test passed')
+            print("=" * 100 + "Test passed")
+
 
 async def main():
     async with create_task_group() as tg:
         tg.start_soon(signal_handler, tg.cancel_scope)
         await job()
         tg.cancel_scope.cancel()
+
 
 run(main)

--- a/examples/example_sync.py
+++ b/examples/example_sync.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import sys
+
+from yarl import URL
+
+from metis_client import MetisAPI, MetisTokenAuth
+from metis_client.models import MetisCalculationModel, MetisDataSourceModel
+
+API_URL = URL("http://localhost:3000")
+
+try:
+    content = open(sys.argv[1]).read()
+except IndexError:
+    content = """{"attributes":{"immutable_id":42, "species":[{"chemical_symbols":
+["Au"]}],"cartesian_site_positions":[[0,0,0]],"lattice_vectors":[[0,2,2],[2,0,2],[2,2,0]]}}"""
+
+
+client = MetisAPI(API_URL, auth=MetisTokenAuth("admin@test.com"))
+
+print(client.v0.auth.whoami())
+data = client.v0.datasources.create(content)
+if not isinstance(data, MetisDataSourceModel):
+    print(data)
+    exit(1)
+
+calc = client.v0.calculations.create(data.id)
+print(calc)
+if isinstance(calc, MetisCalculationModel):
+    print("=" * 100 + "Test passed")

--- a/metis_client/__init__.py
+++ b/metis_client/__init__.py
@@ -3,3 +3,4 @@
 from .auth import MetisLocalUserAuth, MetisNoAuth, MetisTokenAuth
 from .const import PROJECT_VERSION as __version__
 from .metis import MetisAPI
+from .metis_async import MetisAPIAsync

--- a/metis_client/auth.py
+++ b/metis_client/auth.py
@@ -52,10 +52,6 @@ class MetisTokenAuth(BaseAuthenticator):
         session.headers["Authorization"] = f"Bearer {self._token}"
         return True
 
-    @classmethod
-    def _get_cookie(cls, session: ClientSession, base_url: URL):
-        return session.cookie_jar.filter_cookies(base_url).get("_sid")
-
     async def should_update(self, *_) -> bool:
         return True
 

--- a/metis_client/metis.py
+++ b/metis_client/metis.py
@@ -1,52 +1,164 @@
-"""Main Metis API client"""
+"""Metis API synchronous client"""
 
-from types import TracebackType
-from typing import List, Optional, Type
+from functools import partial
+from typing import Any, Awaitable, Callable, TypeVar, cast
 
-import aiohttp
-from aiohttp import ClientSession, ClientTimeout, TraceConfig
-from aiohttp.hdrs import USER_AGENT
-from aiohttp.typedefs import LooseHeaders, StrOrURL
-from yarl import URL
+from aiohttp.typedefs import StrOrURL
+from asgiref.sync import async_to_sync
+from typing_extensions import Concatenate, ParamSpec, Unpack
 
-from .auth import BaseAuthenticator
-from .client import MetisClient
-from .const import DEFAULT_USER_AGENT
+from .metis_async import MetisAPIAsync, MetisAPIKwargs
 from .models.base import MetisBase
-from .namespaces.root import MetisRootNamespace
-from .namespaces.stream import MetisStreamNamespace
-from .namespaces.v0 import MetisV0Namespace
+from .namespaces.collections import MetisCollectionsCreateKwargs
+
+AsyncClientGetter = Callable[[], MetisAPIAsync]
+ReturnT_co = TypeVar("ReturnT_co", covariant=True)
+ParamT = ParamSpec("ParamT")
+
+
+# pylint: disable=too-few-public-methods
+class MetisNamespaceSyncBase:
+    "Base for synchronous namespaces"
+    _client_getter: AsyncClientGetter
+
+    def __init__(self, client_getter: AsyncClientGetter):
+        self._client_getter = client_getter
+
+
+def to_sync_with_metis_client(
+    func: Callable[Concatenate[Any, MetisAPIAsync, ParamT], Awaitable[ReturnT_co]]
+) -> Callable[Concatenate[Any, ParamT], ReturnT_co]:
+    """
+    Wraps async MetisNamespaceSync's method.
+    - start MetisAPIAsync client,
+    - pass it to the method as first argument after Self,
+    - close client
+    - wrap all with async_to_sync converter
+    """
+
+    async def inner(
+        self: MetisNamespaceSyncBase, *args: ParamT.args, **kwargs: ParamT.kwargs
+    ) -> ReturnT_co:
+        # pylint: disable=protected-access
+        async with self._client_getter() as client:
+            return await func(self, client, *args, **kwargs)
+
+    return cast(Any, async_to_sync(inner))
+
+
+class MetisAuthNamespaceSync(MetisNamespaceSyncBase):
+    """Authentication endpoints namespace"""
+
+    @to_sync_with_metis_client
+    async def login(self, client: MetisAPIAsync, email: str, password: str):
+        "Login"
+        return await client.v0.auth.login(email, password)
+
+    @to_sync_with_metis_client
+    async def whoami(self, client: MetisAPIAsync):
+        "Get self info"
+        return await client.v0.auth.whoami()
+
+
+class MetisDatasourcesNamespaceSync(MetisNamespaceSyncBase):
+    """Datasources endpoints namespace"""
+
+    @to_sync_with_metis_client
+    async def create(self, client: MetisAPIAsync, content: str):
+        "Create data source and wait for result"
+        return await client.v0.datasources.create(content)
+
+    @to_sync_with_metis_client
+    async def delete(self, client: MetisAPIAsync, data_id: int):
+        "Delete data source by id and wait for result"
+        return await client.v0.datasources.delete(data_id)
+
+    @to_sync_with_metis_client
+    async def list(self, client: MetisAPIAsync):
+        "List data sources and wait for result"
+        return await client.v0.datasources.list()
+
+    @to_sync_with_metis_client
+    async def get(self, client: MetisAPIAsync, data_id: int):
+        "Get data source by id"
+        return await client.v0.datasources.get(data_id)
+
+
+class MetisCalculationsNamespaceSync(MetisNamespaceSyncBase):
+    """Calculations endpoints namespace"""
+
+    @to_sync_with_metis_client
+    async def cancel(self, client: MetisAPIAsync, calc_id: int):
+        "Cancel calculation and wait for result"
+        return await client.v0.calculations.cancel(calc_id)
+
+    @to_sync_with_metis_client
+    async def create(self, client: MetisAPIAsync, data_id: int, engine: str = "dummy"):
+        "Create calculation and wait for result"
+        return await client.v0.calculations.create(data_id, engine)
+
+    @to_sync_with_metis_client
+    async def get_engines(self, client: MetisAPIAsync):
+        "Get supported calculation engines"
+        return await client.v0.calculations.get_engines()
+
+    @to_sync_with_metis_client
+    async def list(self, client: MetisAPIAsync):
+        "List all user's calculations and wait for result"
+        return await client.v0.calculations.list()
+
+
+class MetisCollectionsNamespaceSync(MetisNamespaceSyncBase):
+    """Collections endpoints namespace"""
+
+    @to_sync_with_metis_client
+    async def create(
+        self,
+        client: MetisAPIAsync,
+        type_id: int,
+        title: str,
+        **opts: Unpack[MetisCollectionsCreateKwargs],
+    ):
+        "Create collection and wait for result"
+        return await client.v0.collections.create(type_id, title, **opts)
+
+    @to_sync_with_metis_client
+    async def list(self, client: MetisAPIAsync):
+        "List user's collections by criteria and wait for result"
+        return await client.v0.collections.list()
+
+    @to_sync_with_metis_client
+    async def delete(self, client: MetisAPIAsync, collection_id: int):
+        "Remove a collection by id and wait for result"
+        return await client.v0.collections.delete(collection_id)
+
+
+# pylint: disable=too-few-public-methods
+class MetisV0NamespaceSync(MetisNamespaceSyncBase):
+    """v0 namespace"""
+
+    def __init__(self, client_getter: AsyncClientGetter):
+        super().__init__(client_getter)
+        self.auth = MetisAuthNamespaceSync(client_getter)
+        self.calculations = MetisCalculationsNamespaceSync(client_getter)
+        self.collections = MetisCollectionsNamespaceSync(client_getter)
+        self.datasources = MetisDatasourcesNamespaceSync(client_getter)
 
 
 class MetisAPI(MetisBase):
-    """
-    This is the main class to use.
-    """
-
-    _close_session = False
-    _session: aiohttp.ClientSession
+    """Metis API synchronous client"""
 
     def __init__(
-        self,
-        base_url: StrOrURL,
-        auth: BaseAuthenticator,
-        session: Optional[ClientSession] = None,
-        headers: Optional[LooseHeaders] = None,
-        timeout: Optional[int] = None,
-        client_name: Optional[str] = None,
-        trace_configs: Optional[List[TraceConfig]] = None,
+        self, base_url: StrOrURL, **opts: Unpack[MetisAPIKwargs]
     ):  # pylint: disable=too-many-arguments
         """
-        Initialize Metis client.
+        Initialize sync Metis client.
+        Sync client is a tiny wrapper over full async client.
 
         **Arguments**:
 
         `bese_url`
         URL of Metis BFF server. `str` or `yarl.URL`.
-
-        `session` (Optional)
-        `aiohttp.ClientSession` to be used by this package.
-        If you do not pass one, one will be created for you.
 
         `headers` (Optional)
         Optional dictionary of always sent headers. Used if `session` is omitted.
@@ -57,49 +169,10 @@ class MetisAPI(MetisBase):
 
         `client_name` (Optional)
         Optional string for user agent.
-        Used if `session` is omitted.
         """
-        headers = headers or {}
-        if session is None:
-            session = aiohttp.ClientSession(
-                timeout=timeout
-                if isinstance(timeout, ClientTimeout)
-                else ClientTimeout(total=timeout),
-                headers=headers,
-                trace_configs=trace_configs,
-            )
-            session.headers[USER_AGENT] = client_name or DEFAULT_USER_AGENT
-            self._close_session = True
-        self._session = session
-
-        base_url = URL(base_url)
-        client = MetisClient(session, base_url, auth)
-        self._ns_root = MetisRootNamespace(client, base_url)
+        self._ns_v0 = MetisV0NamespaceSync(partial(MetisAPIAsync, base_url, **opts))
 
     @property
-    def v0(self) -> MetisV0Namespace:  # pylint: disable=invalid-name
+    def v0(self) -> MetisV0NamespaceSync:  # pylint: disable=invalid-name
         """Property to access the v0 namespace."""
-        return self._ns_root.v0
-
-    @property
-    def stream(self) -> MetisStreamNamespace:
-        """Property to access the stream namespace."""
-        return self._ns_root.stream
-
-    async def __aenter__(self) -> "MetisAPI":
-        """Async enter."""
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
-    ) -> None:
-        await self.close()
-
-    async def close(self) -> None:
-        "Close stream and http session"
-        self.stream.close()
-        if self._session and self._close_session:
-            return await self._session.close()
+        return self._ns_v0

--- a/metis_client/metis_async.py
+++ b/metis_client/metis_async.py
@@ -1,0 +1,110 @@
+"""Main Metis API async client"""
+
+from types import TracebackType
+from typing import List, Optional, Type
+
+import aiohttp
+from aiohttp import ClientSession, ClientTimeout, TraceConfig
+from aiohttp.hdrs import USER_AGENT
+from aiohttp.typedefs import LooseHeaders, StrOrURL
+from typing_extensions import NotRequired, TypedDict, Unpack
+from yarl import URL
+
+from .auth import BaseAuthenticator
+from .client import MetisClient
+from .const import DEFAULT_USER_AGENT
+from .models.base import MetisBase
+from .namespaces.root import MetisRootNamespace
+from .namespaces.stream import MetisStreamNamespace
+from .namespaces.v0 import MetisV0Namespace
+
+
+class MetisAPIKwargs(TypedDict):
+    "MetisAPI init kwargs"
+    auth: BaseAuthenticator
+    headers: NotRequired[LooseHeaders]
+    timeout: NotRequired[int]
+    client_name: NotRequired[str]
+    trace_configs: NotRequired[List[TraceConfig]]
+
+
+class MetisAPIAsync(MetisBase):
+    """Main Metis API async client"""
+
+    _close_session = False
+    _session: aiohttp.ClientSession
+
+    def __init__(
+        self,
+        base_url: StrOrURL,
+        session: Optional[ClientSession] = None,
+        **opts: Unpack[MetisAPIKwargs],
+    ):
+        """
+        Initialize async Metis client.
+
+        **Arguments**:
+
+        `bese_url`
+        URL of Metis BFF server. `str` or `yarl.URL`.
+
+        `session` (Optional)
+        `aiohttp.ClientSession` to be used by this package.
+        If you do not pass one, one will be created for you.
+
+        `headers` (Optional)
+        Optional dictionary of always sent headers. Used if `session` is omitted.
+
+        `timeout` (Optional)
+        Optional integer of global timeout in seconds or `aiohttp.ClientTimeout`.
+        Used if `session` is omitted.
+
+        `client_name` (Optional)
+        Optional string for user agent.
+        Used if `session` is omitted.
+        """
+        headers = opts.get("headers")
+        if session is None:
+            timeout = opts.get("timeout")
+            session = aiohttp.ClientSession(
+                timeout=timeout
+                if isinstance(timeout, ClientTimeout)
+                else ClientTimeout(total=timeout),
+                headers=headers,
+                trace_configs=opts.get("trace_configs"),
+            )
+            session.headers[USER_AGENT] = opts.get("client_name", DEFAULT_USER_AGENT)
+            self._close_session = True
+        self._session = session
+
+        base_url = URL(base_url)
+        client = MetisClient(session, base_url, opts["auth"])
+        self._ns_root = MetisRootNamespace(client, base_url)
+
+    @property
+    def v0(self) -> MetisV0Namespace:  # pylint: disable=invalid-name
+        """Property to access the v0 namespace."""
+        return self._ns_root.v0
+
+    @property
+    def stream(self) -> MetisStreamNamespace:
+        """Property to access the stream namespace."""
+        return self._ns_root.stream
+
+    async def __aenter__(self) -> "MetisAPIAsync":
+        """Async enter."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        "Close stream and http session"
+        self.stream.close()
+        if self._session and self._close_session:
+            return await self._session.close()

--- a/metis_client/models/__init__.py
+++ b/metis_client/models/__init__.py
@@ -1,0 +1,26 @@
+"""Models"""
+
+from .auth import MetisAuthCredentialsModel, MetisAuthCredentialsRequestDTO
+from .calculation import MetisCalculationDTO, MetisCalculationModel
+from .collection import (
+    MetisCollectionDTO,
+    MetisCollectionModel,
+    MetisCollectionTypeDTO,
+    MetisCollectionTypeModel,
+    MetisCollectionVisibility,
+)
+from .datasource import (
+    MetisDataSourceContentOnlyDTO,
+    MetisDataSourceContentOnlyModel,
+    MetisDataSourceDTO,
+    MetisDataSourceModel,
+)
+from .error import MetisErrorModel
+from .event import (
+    MetisCalculationsEventModel,
+    MetisCollectionsEventModel,
+    MetisDataSourcesEventModel,
+    MetisErrorEventModel,
+    MetisEvent,
+    MetisPongEventModel,
+)

--- a/metis_client/models/auth.py
+++ b/metis_client/models/auth.py
@@ -1,7 +1,8 @@
 """Authentication models"""
 
 from dataclasses import asdict, dataclass
-from typing import TypedDict
+
+from typing_extensions import TypedDict
 
 
 class MetisAuthCredentialsRequestDTO(TypedDict):

--- a/metis_client/models/collection.py
+++ b/metis_client/models/collection.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import Literal, Optional, Sequence, Union
 
+from typing_extensions import TypedDict
+
 from .timestamp import MetisTimestampsDTO, MetisTimestampsModel
 from .user import MetisUserOnlyNameEmailDTO, MetisUserOnlyNameEmailModel
 
@@ -43,24 +45,34 @@ class MetisCollectionTypeModel(MetisTimestampsModel):
         )
 
 
-class MetisCollectionDTO(MetisTimestampsDTO):
+class MetisCollectionCommonDTO(TypedDict):
+    "Common fields of collection's DTOs"
+
+    title: str
+    typeId: int
+    dataSources: Optional[Sequence[int]]
+    users: Optional[Sequence[int]]
+
+
+class MetisCollectionCreateDTO(MetisCollectionCommonDTO):
+    "Collection create DTO"
+
+    description: Optional[str]
+
+
+class MetisCollectionDTO(MetisCollectionCommonDTO, MetisTimestampsDTO):
     "Collection DTO"
 
     id: int
-    title: str
     description: str
     visibility: MetisCollectionVisibility
 
     userId: int
     userFirstName: Optional[str]
     userLastName: Optional[str]
-    typeId: int
     typeSlug: Optional[str]
     typeLabel: Optional[str]
     typeFlavor: Optional[str]
-
-    dataSources: Optional[Sequence[int]]
-    users: Optional[Sequence[int]]
 
 
 @dataclass(frozen=True)

--- a/metis_client/models/datasource.py
+++ b/metis_client/models/datasource.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import Sequence
 
+from typing_extensions import TypedDict
+
 from .collection import MetisCollectionDTO, MetisCollectionModel
 from .timestamp import MetisTimestampsDTO, MetisTimestampsModel
 from .user import MetisUserOnlyNameEmailDTO, MetisUserOnlyNameEmailModel
@@ -21,6 +23,11 @@ class MetisDataSourceDTO(MetisTimestampsDTO):
     type: int
     collections: Sequence[MetisCollectionDTO]
     progress: int
+
+
+class MetisDataSourceContentOnlyDTO(TypedDict):
+    "Data source content only DTO"
+    content: str
 
 
 @dataclass(frozen=True)
@@ -58,3 +65,17 @@ class MetisDataSourceModel(MetisTimestampsModel):
             created_at=tsm.created_at,
             updated_at=tsm.updated_at,
         )
+
+
+@dataclass(frozen=True)
+class MetisDataSourceContentOnlyModel:
+    "Data source content only model"
+
+    content: str
+
+    @classmethod
+    def from_dto(
+        cls, dto: MetisDataSourceContentOnlyDTO
+    ) -> "MetisDataSourceContentOnlyModel":
+        "Create model from DTO"
+        return cls(content=dto.get("content"))

--- a/metis_client/models/engine.py
+++ b/metis_client/models/engine.py
@@ -1,7 +1,9 @@
 """Engine model"""
 
 from dataclasses import dataclass
-from typing import Any, Optional, TypedDict
+from typing import Any, Optional
+
+from typing_extensions import TypedDict
 
 
 class MetisEngineDTO(TypedDict):

--- a/metis_client/models/error.py
+++ b/metis_client/models/error.py
@@ -1,7 +1,9 @@
 """Error models"""
 
 from dataclasses import dataclass
-from typing import TypedDict, Union
+from typing import Union
+
+from typing_extensions import TypedDict
 
 
 class MetisErrorErrorDTO(TypedDict):

--- a/metis_client/models/resp.py
+++ b/metis_client/models/resp.py
@@ -1,7 +1,8 @@
 "Base response model"
 
 from dataclasses import dataclass
-from typing import TypedDict
+
+from typing_extensions import TypedDict
 
 
 class MetisRequestIdDTO(TypedDict):
@@ -17,4 +18,4 @@ class MetisRequestIdModel:
     @classmethod
     def from_dto(cls, data: MetisRequestIdDTO) -> "MetisRequestIdModel":
         "Create model from response"
-        return cls(request_id=data.get("reqId"))
+        return cls(request_id=data["reqId"])

--- a/metis_client/models/timestamp.py
+++ b/metis_client/models/timestamp.py
@@ -2,15 +2,16 @@
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, TypedDict
+
+from typing_extensions import NotRequired, TypedDict
 
 from ..helpers import parse_rfc3339
 
 
 class MetisTimestampsDTO(TypedDict):
     "Response with timestamps"
-    createdAt: Optional[str]
-    updatedAt: Optional[str]
+    createdAt: NotRequired[str]
+    updatedAt: NotRequired[str]
 
 
 @dataclass(frozen=True)

--- a/metis_client/models/user.py
+++ b/metis_client/models/user.py
@@ -1,7 +1,9 @@
 """User models"""
 
 from dataclasses import dataclass
-from typing import Dict, Optional, TypedDict
+from typing import Dict, Optional
+
+from typing_extensions import TypedDict
 
 from .timestamp import MetisTimestampsDTO
 

--- a/metis_client/namespaces/calculations.py
+++ b/metis_client/namespaces/calculations.py
@@ -1,13 +1,45 @@
 """Calculations endpoints namespace"""
+from functools import partial
+from typing import Sequence, Union
+
+from ..models.calculation import MetisCalculationModel
+from ..models.error import MetisErrorModel
+from ..models.event import MetisCalculationsEventModel, MetisErrorEventModel
+from ..models.pubsub import act_and_get_result_from_stream
 from ..models.resp import MetisRequestIdModel
 from .base import BaseNamespace
 
 
-# pylint: disable=too-few-public-methods
 class MetisCalculationsNamespace(BaseNamespace):
     """Calculations endpoints namespace"""
 
-    async def create(self, data_id: int, engine: str = "dummy"):
+    async def cancel_event(self, calc_id: int) -> MetisRequestIdModel:
+        "Cancel calculation"
+        async with await self._client.request(
+            method="DELETE",
+            url=self._base_url / str(calc_id),
+            auth_required=True,
+        ) as resp:
+            result = await resp.json()
+            return MetisRequestIdModel.from_dto(result)
+
+    async def cancel(
+        self, calc_id: int
+    ) -> Union[MetisCalculationModel, MetisErrorModel, None]:
+        "Cancel calculation and wait for result"
+        evt = await act_and_get_result_from_stream(
+            self._root.stream.subscribe, partial(self.cancel_event, calc_id)
+        )
+        if MetisErrorEventModel.guard(evt) and evt.errors:
+            return evt.errors[-1]
+        if MetisCalculationsEventModel.guard(evt):
+            for calc in evt.data:
+                if calc.id == calc_id:
+                    return calc
+
+    async def create_event(
+        self, data_id: int, engine: str = "dummy"
+    ) -> MetisRequestIdModel:
         "Create calculation"
         async with await self._client.request(
             method="POST",
@@ -17,3 +49,47 @@ class MetisCalculationsNamespace(BaseNamespace):
         ) as resp:
             result = await resp.json()
             return MetisRequestIdModel.from_dto(result)
+
+    async def create(
+        self, data_id: int, engine: str = "dummy"
+    ) -> Union[MetisCalculationModel, MetisErrorModel, None]:
+        "Create calculation and wait for result"
+        evt = await act_and_get_result_from_stream(
+            self._root.stream.subscribe, partial(self.create_event, data_id, engine)
+        )
+        if MetisErrorEventModel.guard(evt) and evt.errors:
+            return evt.errors[-1]
+        if MetisCalculationsEventModel.guard(evt):
+            data = sorted(evt.data, key=lambda x: x.created_at)
+            return data[-1] if data else None
+
+    async def get_engines(self) -> Sequence[str]:
+        "Get supported calculation engines"
+        async with await self._client.request(
+            method="GET",
+            url=self._base_url / "engines",
+            auth_required=False,
+        ) as resp:
+            return await resp.json()
+
+    async def list_event(self) -> MetisRequestIdModel:
+        "List all user's calculations"
+        async with await self._client.request(
+            method="GET",
+            url=self._base_url,
+            auth_required=True,
+        ) as resp:
+            result = await resp.json()
+            return MetisRequestIdModel.from_dto(result)
+
+    async def list(
+        self,
+    ) -> Union[MetisErrorModel, Sequence[MetisCalculationModel], None]:
+        "List all user's calculations and wait for result"
+        evt = await act_and_get_result_from_stream(
+            self._root.stream.subscribe, partial(self.list_event)
+        )
+        if MetisErrorEventModel.guard(evt) and evt.errors:
+            return evt.errors[-1]
+        if MetisCalculationsEventModel.guard(evt):
+            return evt.data

--- a/metis_client/namespaces/collections.py
+++ b/metis_client/namespaces/collections.py
@@ -1,0 +1,97 @@
+"""Collections endpoints namespace"""
+from functools import partial
+from typing import Optional, Sequence, Union
+
+from typing_extensions import NotRequired, TypedDict, Unpack
+
+from ..models.collection import MetisCollectionCreateDTO, MetisCollectionModel
+from ..models.error import MetisErrorModel
+from ..models.event import MetisCollectionsEventModel, MetisErrorEventModel
+from ..models.pubsub import act_and_get_result_from_stream
+from ..models.resp import MetisRequestIdModel
+from .base import BaseNamespace
+
+
+class MetisCollectionsCreateKwargs(TypedDict):
+    "MetisCollectionsNamespace.create kwargs"
+    description: NotRequired[str]
+    data_source_ids: NotRequired[Sequence[int]]
+    user_ids: NotRequired[Sequence[int]]
+
+
+class MetisCollectionsNamespace(BaseNamespace):
+    """Collections endpoints namespace"""
+
+    async def create_event(
+        self, type_id: int, title: str, **opts: Unpack[MetisCollectionsCreateKwargs]
+    ) -> MetisRequestIdModel:
+        "Create collection"
+        payload = MetisCollectionCreateDTO(
+            title=title,
+            typeId=type_id,
+            description=opts.get("description"),
+            dataSources=opts.get("data_source_ids"),
+            users=opts.get("user_ids"),
+        )
+        async with await self._client.request(
+            method="PUT",
+            url=self._base_url,
+            json=payload,
+            auth_required=True,
+        ) as resp:
+            result = await resp.json()
+            return MetisRequestIdModel.from_dto(result)
+
+    async def create(
+        self, type_id: int, title: str, **opts: Unpack[MetisCollectionsCreateKwargs]
+    ) -> Union[MetisCollectionModel, MetisErrorModel, None]:
+        "Create collection and wait for result"
+        evt = await act_and_get_result_from_stream(
+            self._root.stream.subscribe,
+            partial(self.create_event, type_id, title, **opts),
+        )
+        if MetisErrorEventModel.guard(evt) and evt.errors:
+            return evt.errors[-1]
+        if MetisCollectionsEventModel.guard(evt):
+            data = sorted(evt.data, key=lambda x: x.created_at)
+            return data[-1] if data else None
+
+    async def list_event(self) -> MetisRequestIdModel:
+        "List user's collections by criteria"
+        async with await self._client.request(
+            method="GET",
+            url=self._base_url,
+            auth_required=True,
+        ) as resp:
+            result = await resp.json()
+            return MetisRequestIdModel.from_dto(result)
+
+    async def list(
+        self,
+    ) -> Union[MetisErrorModel, Sequence[MetisCollectionModel], None]:
+        "List user's collections by criteria and wait for result"
+        evt = await act_and_get_result_from_stream(
+            self._root.stream.subscribe, partial(self.list_event)
+        )
+        if MetisErrorEventModel.guard(evt) and evt.errors:
+            return evt.errors[-1]
+        if MetisCollectionsEventModel.guard(evt):
+            return evt.data
+
+    async def delete_event(self, collection_id: int) -> MetisRequestIdModel:
+        "Remove a collection"
+        async with await self._client.request(
+            method="DELETE",
+            url=self._base_url / str(collection_id),
+            auth_required=True,
+        ) as resp:
+            result = await resp.json()
+            return MetisRequestIdModel.from_dto(result)
+
+    async def delete(self, collection_id: int) -> Optional[MetisErrorModel]:
+        "Remove a collection by id and wait for result"
+        evt = await act_and_get_result_from_stream(
+            self._root.stream.subscribe, partial(self.delete_event, collection_id)
+        )
+        if MetisErrorEventModel.guard(evt) and evt.errors:
+            return evt.errors[-1]

--- a/metis_client/namespaces/datasources.py
+++ b/metis_client/namespaces/datasources.py
@@ -1,23 +1,20 @@
 """Datasources endpoints namespace"""
 
+from functools import partial
+from typing import Optional, Sequence, Union
+
+from ..models.datasource import MetisDataSourceContentOnlyModel, MetisDataSourceModel
+from ..models.error import MetisErrorModel
+from ..models.event import MetisDataSourcesEventModel, MetisErrorEventModel
+from ..models.pubsub import act_and_get_result_from_stream
 from ..models.resp import MetisRequestIdModel
 from .base import BaseNamespace
 
 
-# pylint: disable=too-few-public-methods
 class MetisDatasourcesNamespace(BaseNamespace):
     """Datasources endpoints namespace"""
 
-    async def list(self):
-        "List data sources"
-        async with self._client.request(
-            method="GET",
-            url=self._base_url,
-            auth_required=True,
-        ) as resp:
-            return MetisRequestIdModel.from_dto(await resp.json())
-
-    async def create(self, content: str):
+    async def create_event(self, content: str) -> MetisRequestIdModel:
         "Create data source"
         async with self._client.request(
             method="POST",
@@ -27,18 +24,20 @@ class MetisDatasourcesNamespace(BaseNamespace):
         ) as resp:
             return MetisRequestIdModel.from_dto(await resp.json())
 
-    # async def get(self, data_id: int):
-    #     "Get data source by id"
-    #     async with self._client.request(
-    #         method="GET",
-    #         url=self._base_url / str(data_id),
-    #         auth_required=True,
-    #     ) as resp:
-    #         # print(await resp.json())
-    #         # WTF THIS IS BROKEN
-    #         return MetisDataSourceModel.from_dto(await resp.json())
+    async def create(
+        self, content: str
+    ) -> Union[MetisDataSourceModel, MetisErrorModel, None]:
+        "Create data source and wait for result"
+        evt = await act_and_get_result_from_stream(
+            self._root.stream.subscribe, partial(self.create_event, content)
+        )
+        if MetisErrorEventModel.guard(evt) and evt.errors:
+            return evt.errors[-1]
+        if MetisDataSourcesEventModel.guard(evt):
+            data = sorted(evt.data, key=lambda x: x.created_at)
+            return data[-1] if data else None
 
-    async def delete(self, data_id: int):
+    async def delete_event(self, data_id: int) -> MetisRequestIdModel:
         "Delete data source by id"
         async with self._client.request(
             method="DELETE",
@@ -46,3 +45,41 @@ class MetisDatasourcesNamespace(BaseNamespace):
             auth_required=True,
         ) as resp:
             return MetisRequestIdModel.from_dto(await resp.json())
+
+    async def delete(self, data_id: int) -> Optional[MetisErrorModel]:
+        "Delete data source by id and wait for result"
+        evt = await act_and_get_result_from_stream(
+            self._root.stream.subscribe, partial(self.delete_event, data_id)
+        )
+        if MetisErrorEventModel.guard(evt) and evt.errors:
+            return evt.errors[-1]
+
+    async def list_event(self) -> MetisRequestIdModel:
+        "List data sources"
+        async with self._client.request(
+            method="GET",
+            url=self._base_url,
+            auth_required=True,
+        ) as resp:
+            return MetisRequestIdModel.from_dto(await resp.json())
+
+    async def list(
+        self,
+    ) -> Union[MetisErrorModel, Sequence[MetisDataSourceModel], None]:
+        "List data sources and wait for result"
+        evt = await act_and_get_result_from_stream(
+            self._root.stream.subscribe, partial(self.list_event)
+        )
+        if MetisErrorEventModel.guard(evt) and evt.errors:
+            return evt.errors[-1]
+        if MetisDataSourcesEventModel.guard(evt):
+            return evt.data
+
+    async def get(self, data_id: int) -> MetisDataSourceContentOnlyModel:
+        "Get data source by id"
+        async with self._client.request(
+            method="GET",
+            url=self._base_url / str(data_id),
+            auth_required=True,
+        ) as resp:
+            return MetisDataSourceContentOnlyModel.from_dto(await resp.json())

--- a/metis_client/namespaces/v0.py
+++ b/metis_client/namespaces/v0.py
@@ -3,6 +3,7 @@
 from .auth import MetisAuthNamespace
 from .base import BaseNamespace
 from .calculations import MetisCalculationsNamespace
+from .collections import MetisCollectionsNamespace
 from .datasources import MetisDatasourcesNamespace
 
 
@@ -15,6 +16,9 @@ class MetisV0Namespace(BaseNamespace):
         )
         self.__ns_calculations = MetisCalculationsNamespace(
             self._client, self._base_url / "calculations", root=self._root
+        )
+        self.__ns_collections = MetisCollectionsNamespace(
+            self._client, self._base_url / "collections", root=self._root
         )
         self.__ns_datasources = MetisDatasourcesNamespace(
             self._client, self._base_url / "datasources", root=self._root
@@ -33,6 +37,11 @@ class MetisV0Namespace(BaseNamespace):
     def calculations(self) -> MetisCalculationsNamespace:
         "Property to access the calculations namespace."
         return self.__ns_calculations
+
+    @property
+    def collections(self) -> MetisCollectionsNamespace:
+        "Property to access the collections namespace."
+        return self.__ns_collections
 
     @property
     def datasources(self) -> MetisDatasourcesNamespace:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,11 @@ classifiers = [
 keywords = ["metis", "client"]
 requires-python = ">=3.8"
 dependencies = [
+    "asgiref >= 3.5.2",
     "aiohttp >= 3.7.4",
     "aiohttp-sse-client >= 0.2.1",
-    # because of TypeGuard, Self
-    "typing-extensions >= 4.0.1, < 5; python_version < '3.10'",
+    # because of TypeGuard, Self, Unpack, ParamSpec, Concatenate, NotRequired
+    "typing-extensions >= 4.2.0, < 5; python_version < '3.11'",
     "yarl >= 1.6.3, < 2.0",
 ]
 
@@ -49,22 +50,14 @@ lint = [
      "flake8",
      "flake8-bugbear",
      "isort",
+     "mypy >= 1.0.0, <2",
      "pylint",
      "pyupgrade",
 ]
-testing = [
-#     "mock==2.0.0",
-#     "pgtest>=1.1.0",
-#     "pytest-aiohttp",
-#     "sqlalchemy-diff==0.1.3",
-#     "pytest>=6.2.0",
-#     "wheel>=0.31",
-#     "aiida-testing-dev",
-#     "coverage",
-#     "flake8",
-#     "pytest",
-#     "pytest-cov",
-#     "pytest-timeout",
+test = [
+    "pgtest",
+    "pytest-aiohttp >= 1.0.4, <2",
+    "pytest-cov",
 ]
 
 [project.urls]
@@ -96,6 +89,11 @@ default_section = "THIRDPARTY"
 ensure_newline_before_comments = true
 py_version = 38
 
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+
 [tool.pylint.main]
 jobs = 0
 py-version = "3.8"
@@ -117,3 +115,7 @@ max-line-length = 88
 output-format = "colorized"
 reports = "no"
 score = "no"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+


### PR DESCRIPTION
Support of all BFF endpoints except for GUI_ONLY.
Create "simple" request-response method with stream machinery hidden under the hood.
Create synchronous client, where all async methods wrapped and converted to synchronous.