### PR TITLE
Specify packages required for PyPI releasing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ test = [
     "pytest-aiohttp >= 1.0.4, <2",
     "pytest-cov",
 ]
+pypi = [
+     "build",
+     "twine",
+]
 
 [project.urls]
 Source = "https://github.com/tilde-lab/metis-client"


### PR DESCRIPTION
@knopki shouldn't we specify this? Please, feel free to reject, if redundant.