### PR TITLE
feat: more vebrose exception

### DIFF
--- a/metis_client/exc.py
+++ b/metis_client/exc.py
@@ -32,6 +32,9 @@ class MetisError(MetisException):
         if message:
             self.message = message
 
+    def __str__(self) -> str:
+        return f"status: {self.status}, message: {self.message}"
+
 
 class MetisNotFoundException(MetisError):
     """This is raised when the requested resource is not found."""

--- a/tests/test_exc.py
+++ b/tests/test_exc.py
@@ -1,0 +1,12 @@
+"Test MetisError"
+
+from metis_client.exc import MetisError
+
+
+def test_error_string():
+    "Test MetisError"
+    status = -1234
+    message = "mEsSaGe"
+    err = MetisError(status=status, message=message)
+    assert str(status) in str(err), "Status should be printed"
+    assert str(message) in str(err), "Message should be printed"


### PR DESCRIPTION
Example:
```
metis_client.exc.MetisError: status: 421, message: connect ECONNREFUSED 10.89.1.67:7050
```
instead of just
```
metis_client.exc.MetisError
```