### PR TITLE
fix: example

### DIFF
--- a/examples/example_sync.py
+++ b/examples/example_sync.py
@@ -25,12 +25,10 @@ data = client.v0.datasources.create(CONTENT)
 print(data)
 assert data
 
-calc = client.v0.calculations.create(data.id, engine="topas")
+calc = client.v0.calculations.create(data.get("id"), engine="topas")
 print(calc)
 assert calc
 
-res = client.v0.calculations.cancel(calc.id)
-print(res)
-assert res
+client.v0.calculations.cancel(calc.get("id"))
 
 print("=" * 100 + "Test passed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,4 +122,4 @@ score = "no"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "--cov=metis_client --cov-report=term --cov-report=html --no-cov-on-fail --cov-fail-under=99"
+addopts = "--cov=metis_client --cov-report=term --no-cov-on-fail --cov-fail-under=99"


### PR DESCRIPTION
Regression in example. Used old dataclass syntax. Also, last print and assert is useless - `.cancel()` returns nothing.