### PR TITLE
Release automations

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,9 +2,9 @@
 # yamllint disable rule:line-length
 name: Lint Code Base
 
-on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+on: # yamllint disable-line rule:truthy rule:comments
+  # allow this workflow to be called from other workflows
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,39 @@
+---
+# yamllint disable rule:line-length
+name: PR action
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  lint:
+    uses: ./.github/workflows/linter.yml
+
+  test:
+    uses: ./.github/workflows/test.yml
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        if: ${{ !env.ACT }} # skip during local actions testing
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[release]
+
+      - name: Build
+        run: flit build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,71 @@
+---
+# yamllint disable rule:line-length
+name: Push action
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  release:
+    name: Bump version and create draft release
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        if: ${{ !env.ACT }} # skip during local actions testing
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[release]
+
+      - name: Create bump and changelog
+        id: cz
+        uses: commitizen-tools/commitizen-action@e41bf7f2029bc8175af362badd6fd0860a329b0f
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          changelog_increment_filename: .CHANGELOG-CURRENT.md
+          push: true
+          commit: true
+
+      - name: Print new version
+        run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
+
+      - name: Build
+        run: flit build
+
+      - name: Stop if no bump
+        id: no-bump
+        continue-on-error: true
+        # will fail if not on exact tag
+        run: git describe --tags --exact-match
+
+      - name: Create Release Draft
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        if: steps.no-bump.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          draft: true
+          tag_name: v${{ steps.cz.outputs.version }}
+          body_path: .CHANGELOG-CURRENT.md
+          fail_on_unmatched_files: true
+          files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+---
+# yamllint disable rule:line-length
+name: Publish release to pypi
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        if: ${{ !env.ACT }} # skip during local actions testing
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[release]
+
+      - name: Build
+        run: flit build
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,10 @@
 ---
 # yamllint disable rule:line-length
-name: Test, build and release
+name: Run tests
 
-on:
-  pull_request:
-    types: [opened, reopened, synchronize]
-  push:
-    branches:
-      - master
-    tags:
-      - "v*.*.*"
+on: # yamllint disable-line rule:truthy rule:comments
+  # allow this workflow to be called from other workflows
+  workflow_call:
 
 jobs:
   test:
@@ -31,8 +26,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: |
-            pyproject.toml
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -47,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v3
         # Use always() to always run this step to publish test results
         # when there are test failures
-        if: ${{ always() }}
+        if: always()
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Current version's temporary CHANGELOG
+.CHANGELOG-CURRENT.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+## v0.0.3 (2023-03-02)
+
+### Feat
+
+- tests GH action
+- tests
+- full API coverage and refactor to TypedDicts
+- sync client
+- implement all endpoints and more user friendly async api
+- lint github action
+- setup linters
+- setup dependabot
+
+### Fix
+
+- remove hardcoded type flavors

--- a/metis_client/const.py
+++ b/metis_client/const.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from logging import Logger, getLogger
 from typing import Literal, Union
 
-PROJECT_VERSION = "0.0.4"
+PROJECT_VERSION = "0.0.3"
 PROJECT_NAME = "metis_client"
 
 # This is the default user agent,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ test = [
     "pytest-aiohttp >= 1.0.4, <2",
     "pytest-cov",
 ]
+release = [
+    "flit",
+]
 
 [project.urls]
 Source = "https://github.com/tilde-lab/metis-client"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "metis-client"
-dynamic = ["version"]  # read from metis_client/__init__.py
+version = "0.0.3"
 description = """Metis infra API client in Python"""
 authors = [{name = "Sergei Korolev", email = "knopki@duck.com"}]
 readme = "README.md"
@@ -56,10 +56,14 @@ test = [
     "pytest-cov",
 ]
 release = [
+    "commitizen",
     "flit",
 ]
 
 [project.urls]
+Home = "https://github.com/tilde-lab/metis-client"
+Changelog = "https://github.com/tilde-lab/metis-client/blob/master/CHANGELOG.md"
+Issues = "https://github.com/tilde-lab/metis-client/issues"
 Source = "https://github.com/tilde-lab/metis-client"
 
 [tool.flit.module]
@@ -126,3 +130,14 @@ score = "no"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 addopts = "--cov=metis_client --cov-report=term --no-cov-on-fail --cov-fail-under=99"
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.0.3"
+tag_format = "v$version"
+major_version_zero = true
+version_files = [
+    "pyproject.toml:^version",
+    "metis_client/const.py:^PROJECT_VERSION",
+]
+update_changelog_on_bump = true


### PR DESCRIPTION
Closes #7 

Refactor workflows:

PR (before merge): Lint, test, build.

Push to `master`:
Test, maybe bump version (conventional commits specification).
If no version bump - just build.
If version bump - create git tag, bump version in files, generate and commit changelog, build, create draft github release.

On release publish: Build and upload to PyPI.

@blokhin Please, set `PYPI_API_TOKEN` secret.