### PR TITLE
Timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ A synchronous client is `MetisAPI`. Example of usage:
 ```python
 from metis_client import MetisAPI, MetisTokenAuth
 
-client = MetisAPI(API_URL, auth=MetisTokenAuth("VERY_SECRET_TOKEN"))
+client = MetisAPI(API_URL, auth=MetisTokenAuth("VERY_SECRET_TOKEN"), timeout=5)
 data = client.v0.datasources.create(content)
-results = client.v0.calculations.create_get_results(data["id"])
+results = client.v0.calculations.create_get_results(data["id"], timeout=False)
 print(results)
 ```
 

--- a/metis_client/client.py
+++ b/metis_client/client.py
@@ -141,7 +141,7 @@ class MetisClient(MetisBase):
                 result.close()
                 return await self._request(url, **opts)
 
-        except (CancelledError, ClientConnectionError) as exc:
+        except ClientConnectionError as exc:
             raise MetisConnectionException(
                 f"Request exception for {str(url)!r} with - {exc}"
             ) from exc

--- a/metis_client/dtos/event.py
+++ b/metis_client/dtos/event.py
@@ -80,6 +80,7 @@ class MetisCollectionsEventDTO(TypedDict):
     data: MetisCollectionsEventDataDTO
 
 
+# pylint: disable=invalid-name
 MetisEventDTO = Union[
     MetisCalculationsEventDTO,
     MetisCollectionsEventDTO,

--- a/metis_client/metis_async.py
+++ b/metis_client/metis_async.py
@@ -2,7 +2,7 @@
 
 import sys
 from types import TracebackType
-from typing import Optional, Type
+from typing import Literal, Optional, Type, Union
 
 import aiohttp
 from aiohttp import ClientSession, ClientTimeout, TraceConfig
@@ -32,7 +32,7 @@ class MetisAPIKwargs(TypedDict):
     "MetisAPI init kwargs"
     auth: BaseAuthenticator
     headers: NotRequired[LooseHeaders]
-    timeout: NotRequired[int]
+    timeout: NotRequired[Union[float, Literal[False], None]]
     client_name: NotRequired[str]
     trace_configs: NotRequired[List[TraceConfig]]
 
@@ -65,8 +65,8 @@ class MetisAPIAsync(MetisBase):
         Optional dictionary of always sent headers. Used if `session` is omitted.
 
         `timeout` (Optional)
-        Optional integer of global timeout in seconds or `aiohttp.ClientTimeout`.
-        Used if `session` is omitted.
+        Optional float timeout in seconds. None if not timeout. False if not set.
+        Used as `aiohttp` timeout if `session` is omitted.
 
         `client_name` (Optional)
         Optional string for user agent.
@@ -74,11 +74,11 @@ class MetisAPIAsync(MetisBase):
         """
         headers = opts.get("headers")
         if session is None:
-            timeout = opts.get("timeout")
+            timeout = opts.get("timeout", None)
             session = aiohttp.ClientSession(
                 timeout=timeout
                 if isinstance(timeout, ClientTimeout)
-                else ClientTimeout(total=timeout),
+                else ClientTimeout(total=timeout or None),
                 headers=headers,
                 trace_configs=opts.get("trace_configs"),
             )

--- a/metis_client/models/subscription.py
+++ b/metis_client/models/subscription.py
@@ -84,10 +84,7 @@ class MetisSubscription(MetisBase):
 
     @asynccontextmanager
     async def _cm(self):
-        try:
-            yield await self.queue.get()
-        finally:
-            self.queue.task_done()
+        yield await self.queue.get()
 
     async def __anext__(self) -> MetisEventDTO:
         async with self._cm() as msg:

--- a/metis_client/namespaces/stream.py
+++ b/metis_client/namespaces/stream.py
@@ -60,6 +60,8 @@ class MetisStreamNamespace(BaseNamespace):
         "Close background stream consumer"
         if self._stream_task:
             self._stream_task.cancel()
+        if self._sse_client_task:
+            self._sse_client_task.cancel()
 
     def subscribe(self, predicate: Optional[Callable[[MetisEventDTO], bool]] = None):
         "Subscribe to stream"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -169,24 +169,6 @@ async def test_too_many_request(
     assert resp.ok, "Should tolerate too many requests"
 
 
-async def test_cancelled_error(
-    client: MetisClient,
-):  # pylint: disable=redefined-outer-name
-    "Test CancelledError"
-
-    async def fetch():
-        await client.request(URL(PATH_SLOW_RESPONSE))
-
-    task = asyncio.create_task(fetch())
-    await asyncio.sleep(0.0001)
-    task.cancel()
-    with pytest.raises(MetisConnectionException) as exc_info:
-        await task
-    assert (
-        "Request exception" in exc_info.value.args[0]
-    ), "MetisClient should handle CancelledError"
-
-
 async def test_client_connection_error(
     client: MetisClient,
 ):  # pylint: disable=redefined-outer-name

--- a/tests/test_metis.py
+++ b/tests/test_metis.py
@@ -1,0 +1,26 @@
+"Test MetisAPI"
+
+import pytest
+
+from metis_client import MetisAPI, MetisNoAuth
+
+
+@pytest.mark.parametrize(
+    "default_timeout, timeout, result",
+    [
+        (False, False, None),
+        (False, None, None),
+        (False, 1, 1),
+        (None, False, None),
+        (None, None, None),
+        (None, 1, 1),
+        (1, False, None),
+        (1, None, 1),
+        (1, 1, 1),
+    ],
+)
+async def test_sync_ns_timeout(default_timeout, timeout, result):
+    "Test timeout guessing method"
+    client = MetisAPI("/", auth=MetisNoAuth(), timeout=default_timeout)
+    # pylint: disable=protected-access
+    assert client.v0._get_timeout(timeout) == result


### PR DESCRIPTION
`MetisAPI` and `MetisAPIAsync` have the optional `timeout` parameter. This is the parameter for `aiohttp`.
In case of synchronous `MetisAPI`, the `timeout` parameter is also a global default timeout for all API calls (including SSE). Each method also has an optional `timeout` parameter. Method's timeout can override the default timeout of the client.

If a timeout occurs, an exception `asyncio.TimeoutError` is thrown.

So it's possible to do something like this:
```python
client = MetisAPI(..., timeout=5) # set default timeout to 5 seconds
try:
    data = client.v0.datasources.create(CONTENT) # timeout here are 5 seconds
    calc = client.v0.calculations.create(data.get("id"), engine=TEST_ENGINE, timeout=False) # timeout is disabled
    results = client.v0.calculations.get_results(calc["id"], timeout=60) # timeout is 60 seconds
except asyncio.TimeoutError:
    print("too long")
```




