### PR TITLE
Implement calls to metis-backend

### DIFF
--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -85,7 +85,7 @@ async def main():
         print(await client.v0.auth.whoami())
         print(
             "The following engines are available:",
-            await client.v0.calculations.get_engines(),
+            await client.calculations.supported(),
         )
 
         await create_calc_then_get_results(client)

--- a/examples/example_sync.py
+++ b/examples/example_sync.py
@@ -85,7 +85,7 @@ def main():
     client = MetisAPI(API_URL, auth=MetisTokenAuth("admin@test.com"))
 
     print(client.v0.auth.whoami())
-    print("The following engines are available:", client.v0.calculations.get_engines())
+    print("The following engines are available:", client.calculations.supported())
 
     create_calc_then_get_results(client)
     create_calc_and_get_results(client)

--- a/metis_client/metis.py
+++ b/metis_client/metis.py
@@ -11,8 +11,8 @@ from metis_client.dtos.datasource import MetisDataSourceDTO
 
 from .metis_async import MetisAPIAsync, MetisAPIKwargs
 from .models.base import MetisBase
-from .namespaces.calculations import MetisCalculationOnProgressT
-from .namespaces.collections import MetisCollectionsCreateKwargs
+from .namespaces.v0_calculations import MetisCalculationOnProgressT
+from .namespaces.v0_collections import MetisCollectionsCreateKwargs
 
 if sys.version_info < (3, 9):  # pragma: no cover
     from typing import Awaitable, Callable
@@ -60,7 +60,7 @@ def to_sync_with_metis_client(
     return cast(Any, async_to_sync(inner))
 
 
-class MetisAuthNamespaceSync(MetisNamespaceSyncBase):
+class MetisV0AuthNamespaceSync(MetisNamespaceSyncBase):
     """Authentication endpoints namespace"""
 
     @to_sync_with_metis_client
@@ -74,7 +74,7 @@ class MetisAuthNamespaceSync(MetisNamespaceSyncBase):
         return await client.v0.auth.whoami()
 
 
-class MetisDatasourcesNamespaceSync(MetisNamespaceSyncBase):
+class MetisV0DatasourcesNamespaceSync(MetisNamespaceSyncBase):
     """Datasources endpoints namespace"""
 
     @to_sync_with_metis_client
@@ -125,7 +125,7 @@ class MetisDatasourcesNamespaceSync(MetisNamespaceSyncBase):
         return await client.v0.datasources.get_content(data_id)
 
 
-class MetisCalculationsNamespaceSync(MetisNamespaceSyncBase):
+class MetisV0CalculationsNamespaceSync(MetisNamespaceSyncBase):
     """Calculations endpoints namespace"""
 
     @to_sync_with_metis_client
@@ -184,7 +184,7 @@ class MetisCalculationsNamespaceSync(MetisNamespaceSyncBase):
         return await client.v0.calculations.get(calc_id)
 
 
-class MetisCollectionsNamespaceSync(MetisNamespaceSyncBase):
+class MetisV0CollectionsNamespaceSync(MetisNamespaceSyncBase):
     """Collections endpoints namespace"""
 
     @to_sync_with_metis_client
@@ -215,10 +215,10 @@ class MetisV0NamespaceSync(MetisNamespaceSyncBase):
 
     def __init__(self, client_getter: AsyncClientGetter):
         super().__init__(client_getter)
-        self.auth = MetisAuthNamespaceSync(client_getter)
-        self.calculations = MetisCalculationsNamespaceSync(client_getter)
-        self.collections = MetisCollectionsNamespaceSync(client_getter)
-        self.datasources = MetisDatasourcesNamespaceSync(client_getter)
+        self.auth = MetisV0AuthNamespaceSync(client_getter)
+        self.calculations = MetisV0CalculationsNamespaceSync(client_getter)
+        self.collections = MetisV0CollectionsNamespaceSync(client_getter)
+        self.datasources = MetisV0DatasourcesNamespaceSync(client_getter)
 
 
 class MetisAPI(MetisBase):

--- a/metis_client/metis.py
+++ b/metis_client/metis.py
@@ -60,6 +60,15 @@ def to_sync_with_metis_client(
     return cast(Any, async_to_sync(inner))
 
 
+class MetisCalculationsNamespaceSync(MetisNamespaceSyncBase):
+    """Calculations endpoints namespace"""
+
+    @to_sync_with_metis_client
+    async def supported(self, client: MetisAPIAsync):
+        "Get supported calculation engines"
+        return await client.calculations.supported()
+
+
 class MetisV0AuthNamespaceSync(MetisNamespaceSyncBase):
     """Authentication endpoints namespace"""
 
@@ -246,7 +255,17 @@ class MetisAPI(MetisBase):
         `client_name` (Optional)
         Optional string for user agent.
         """
+        self._ns_calculations = MetisCalculationsNamespaceSync(
+            partial(MetisAPIAsync, base_url, **opts)
+        )
         self._ns_v0 = MetisV0NamespaceSync(partial(MetisAPIAsync, base_url, **opts))
+
+    @property
+    def calculations(
+        self,
+    ) -> MetisCalculationsNamespaceSync:  # pylint: disable=invalid-name
+        """Property to access the calculations namespace."""
+        return self._ns_calculations
 
     @property
     def v0(self) -> MetisV0NamespaceSync:  # pylint: disable=invalid-name

--- a/metis_client/metis_async.py
+++ b/metis_client/metis_async.py
@@ -13,6 +13,7 @@ from yarl import URL
 from .client import MetisClient
 from .const import DEFAULT_USER_AGENT
 from .models import BaseAuthenticator, MetisBase
+from .namespaces.calculations import MetisCalculationsNamespace
 from .namespaces.root import MetisRootNamespace
 from .namespaces.stream import MetisStreamNamespace
 from .namespaces.v0 import MetisV0Namespace
@@ -91,6 +92,13 @@ class MetisAPIAsync(MetisBase):
             raise TypeError("Base URL should be absolute")
         client = MetisClient(session, base_url, opts["auth"])
         self._ns_root = MetisRootNamespace(client, base_url)
+
+    @property
+    def calculations(
+        self,
+    ) -> MetisCalculationsNamespace:  # pylint: disable=invalid-name
+        """Property to access the calculations namespace."""
+        return self._ns_root.calculations
 
     @property
     def v0(self) -> MetisV0Namespace:  # pylint: disable=invalid-name

--- a/metis_client/namespaces/calculations.py
+++ b/metis_client/namespaces/calculations.py
@@ -1,0 +1,24 @@
+"""Calculations endpoints namespace"""
+import sys
+
+from ..helpers import raise_on_metis_error
+from .base import BaseNamespace
+
+if sys.version_info < (3, 9):  # pragma: no cover
+    from typing import Sequence
+else:  # pragma: no cover
+    from collections.abc import Sequence
+
+
+class MetisCalculationsNamespace(BaseNamespace):
+    """Calculations endpoints namespace"""
+
+    @raise_on_metis_error
+    async def supported(self) -> Sequence[str]:
+        "Get supported calculation engines"
+        async with await self._client.request(
+            method="GET",
+            url=self._base_url / "supported",
+            auth_required=False,
+        ) as resp:
+            return await resp.json()

--- a/metis_client/namespaces/root.py
+++ b/metis_client/namespaces/root.py
@@ -4,6 +4,7 @@ from yarl import URL
 
 from ..client import MetisClient
 from .base import BaseNamespace
+from .calculations import MetisCalculationsNamespace
 from .stream import MetisStreamNamespace
 from .v0 import MetisV0Namespace
 
@@ -19,13 +20,21 @@ class MetisRootNamespace(BaseNamespace):
         auth_req: bool = True,
     ) -> None:
         """Initialise the namespace."""
-        super().__init__(client, base_url, self, auth_req)
+        super().__init__(client, base_url, root or self, auth_req)
 
     def __post_init__(self) -> None:
+        self.__ns_calculations = MetisCalculationsNamespace(
+            self._client, self._base_url / "calculations", root=self
+        )
         self.__ns_v0 = MetisV0Namespace(self._client, self._base_url / "v0", root=self)
         self.__ns_stream = MetisStreamNamespace(
             self._client, self._base_url / "stream", root=self
         )
+
+    @property
+    def calculations(self) -> "MetisCalculationsNamespace":
+        """Property to access the calculations namespace."""
+        return self.__ns_calculations
 
     @property
     def v0(self) -> "MetisV0Namespace":  # pylint: disable=invalid-name

--- a/metis_client/namespaces/v0.py
+++ b/metis_client/namespaces/v0.py
@@ -1,26 +1,26 @@
 """v0 namespace"""
 
-from .auth import MetisAuthNamespace
 from .base import BaseNamespace
-from .calculations import MetisCalculationsNamespace
-from .collections import MetisCollectionsNamespace
-from .datasources import MetisDatasourcesNamespace
+from .v0_auth import MetisV0AuthNamespace
+from .v0_calculations import MetisV0CalculationsNamespace
+from .v0_collections import MetisV0CollectionsNamespace
+from .v0_datasources import MetisV0DatasourcesNamespace
 
 
 class MetisV0Namespace(BaseNamespace):
     """v0 namespace"""
 
     def __post_init__(self) -> None:
-        self.__ns_auth = MetisAuthNamespace(
+        self.__ns_auth = MetisV0AuthNamespace(
             self._client, self._base_url / "auth", root=self._root
         )
-        self.__ns_calculations = MetisCalculationsNamespace(
+        self.__ns_calculations = MetisV0CalculationsNamespace(
             self._client, self._base_url / "calculations", root=self._root
         )
-        self.__ns_collections = MetisCollectionsNamespace(
+        self.__ns_collections = MetisV0CollectionsNamespace(
             self._client, self._base_url / "collections", root=self._root
         )
-        self.__ns_datasources = MetisDatasourcesNamespace(
+        self.__ns_datasources = MetisV0DatasourcesNamespace(
             self._client, self._base_url / "datasources", root=self._root
         )
 
@@ -29,21 +29,21 @@ class MetisV0Namespace(BaseNamespace):
         await self._client.request(url=self._base_url, method="HEAD", json={})
 
     @property
-    def auth(self) -> MetisAuthNamespace:
+    def auth(self) -> MetisV0AuthNamespace:
         "Property to access the auth namespace."
         return self.__ns_auth
 
     @property
-    def calculations(self) -> MetisCalculationsNamespace:
+    def calculations(self) -> MetisV0CalculationsNamespace:
         "Property to access the calculations namespace."
         return self.__ns_calculations
 
     @property
-    def collections(self) -> MetisCollectionsNamespace:
+    def collections(self) -> MetisV0CollectionsNamespace:
         "Property to access the collections namespace."
         return self.__ns_collections
 
     @property
-    def datasources(self) -> MetisDatasourcesNamespace:
+    def datasources(self) -> MetisV0DatasourcesNamespace:
         "Property to access the datasources namespace."
         return self.__ns_datasources

--- a/metis_client/namespaces/v0_auth.py
+++ b/metis_client/namespaces/v0_auth.py
@@ -5,7 +5,7 @@ from ..helpers import dict_dt_from_dt_str, raise_on_metis_error
 from .base import BaseNamespace
 
 
-class MetisAuthNamespace(BaseNamespace):
+class MetisV0AuthNamespace(BaseNamespace):
     """Authentication endpoints namespace"""
 
     @raise_on_metis_error

--- a/metis_client/namespaces/v0_calculations.py
+++ b/metis_client/namespaces/v0_calculations.py
@@ -28,7 +28,7 @@ MetisCalculationOnProgressT = Callable[
 ]
 
 
-class MetisCalculationsNamespace(BaseNamespace):
+class MetisV0CalculationsNamespace(BaseNamespace):
     """Calculations endpoints namespace"""
 
     async def cancel_event(self, calc_id: int) -> MetisRequestIdDTO:

--- a/metis_client/namespaces/v0_calculations.py
+++ b/metis_client/namespaces/v0_calculations.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from functools import partial
 from inspect import iscoroutinefunction
 from typing import Awaitable, Callable, Optional, Union, cast
+from warnings import warn
 
 from ..dtos import (
     DataSourceType,
@@ -167,12 +168,12 @@ class MetisV0CalculationsNamespace(BaseNamespace):
     @raise_on_metis_error
     async def get_engines(self) -> Sequence[str]:
         "Get supported calculation engines"
-        async with await self._client.request(
-            method="GET",
-            url=self._base_url / "engines",
-            auth_required=False,
-        ) as resp:
-            return await resp.json()
+        msg = (
+            "v0.calculations.get_engines() is deprecated; "
+            "please, use calculations.supported() instead"
+        )
+        warn(DeprecationWarning(msg))
+        return await self._root.calculations.supported()
 
     async def list_event(self) -> MetisRequestIdDTO:
         "List all user's calculations"

--- a/metis_client/namespaces/v0_collections.py
+++ b/metis_client/namespaces/v0_collections.py
@@ -21,13 +21,13 @@ else:  # pragma: no cover
 
 
 class MetisCollectionsCreateKwargs(TypedDict):
-    "MetisCollectionsNamespace.create kwargs"
+    "MetisV0CollectionsNamespace.create kwargs"
     description: NotRequired[str]
     data_source_ids: NotRequired[Sequence[int]]
     user_ids: NotRequired[Sequence[int]]
 
 
-class MetisCollectionsNamespace(BaseNamespace):
+class MetisV0CollectionsNamespace(BaseNamespace):
     """Collections endpoints namespace"""
 
     async def create_event(

--- a/metis_client/namespaces/v0_datasources.py
+++ b/metis_client/namespaces/v0_datasources.py
@@ -16,7 +16,7 @@ else:  # pragma: no cover
     from collections.abc import Sequence
 
 
-class MetisDatasourcesNamespace(BaseNamespace):
+class MetisV0DatasourcesNamespace(BaseNamespace):
     """Datasources endpoints namespace"""
 
     async def create_event(

--- a/tests/namespaces/test_calculations.py
+++ b/tests/namespaces/test_calculations.py
@@ -1,0 +1,65 @@
+"Test MetisCalculationsNamespace"
+
+import asyncio
+from datetime import datetime
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from aiohttp.web_exceptions import HTTPOk
+from yarl import URL
+
+from metis_client import MetisAPI, MetisAPIAsync, MetisTokenAuth
+from tests.helpers import random_word
+
+dt = datetime.fromordinal(1)
+TOKEN = random_word(10)
+PATH_C_ENGINES = "/calculations/supported"
+PATH_C_GET_ENGINES_RESPONSE = ["dummy", "other"]
+
+
+async def get_engines_handler(_: web.Request) -> web.Response:
+    "Request handler"
+    return web.json_response(PATH_C_GET_ENGINES_RESPONSE, status=HTTPOk.status_code)
+
+
+async def create_app() -> web.Application:
+    "Create web application"
+    app = web.Application()
+    app.router.add_get(PATH_C_ENGINES, get_engines_handler)
+    return app
+
+
+@pytest.fixture
+async def aiohttp_client_impl(aiohttp_client) -> TestClient:
+    "Create test client"
+    app = await create_app()
+    return await aiohttp_client(TestServer(app))
+
+
+@pytest.fixture
+def base_url(aiohttp_client_impl: TestClient) -> URL:
+    "Return base url"
+    return aiohttp_client_impl.make_url("")
+
+
+@pytest.fixture
+def client(base_url: URL) -> MetisAPI:
+    "Return sync client"
+    return MetisAPI(base_url, auth=MetisTokenAuth(TOKEN))
+
+
+@pytest.fixture
+async def client_async(base_url: URL):
+    "Return sync client"
+    async with MetisAPIAsync(base_url, auth=MetisTokenAuth(TOKEN)) as client:
+        yield client
+
+
+async def test_get_supported(client: MetisAPI, client_async: MetisAPIAsync):
+    "Test get_engines()"
+    en_async = await client_async.calculations.supported()
+    en_sync = await asyncio.get_event_loop().run_in_executor(
+        None, client.calculations.supported
+    )
+    assert en_async == en_sync, "Response matches"

--- a/tests/namespaces/test_v0_auth.py
+++ b/tests/namespaces/test_v0_auth.py
@@ -1,4 +1,4 @@
-"Test MetisAuthNamespace"
+"Test MetisV0AuthNamespace"
 
 import asyncio
 from copy import deepcopy

--- a/tests/namespaces/test_v0_calculations.py
+++ b/tests/namespaces/test_v0_calculations.py
@@ -1,4 +1,4 @@
-"Test MetisCalculationsNamespace"
+"Test MetisV0CalculationsNamespace"
 
 import asyncio
 import json

--- a/tests/namespaces/test_v0_collections.py
+++ b/tests/namespaces/test_v0_collections.py
@@ -1,4 +1,4 @@
-"Test MetisCollectionsNamespace"
+"Test MetisV0CollectionsNamespace"
 
 import asyncio
 import json

--- a/tests/namespaces/test_v0_datasources.py
+++ b/tests/namespaces/test_v0_datasources.py
@@ -1,4 +1,4 @@
-"Test MetisDatasourcesNamespace"
+"Test MetisV0DatasourcesNamespace"
 
 import asyncio
 import json


### PR DESCRIPTION
Implement call to `/calculations/supported`. Deprecate with warning `get_engines()`.