### PR TITLE
Support collections editing and new DS type

### DIFF
--- a/metis_client/dtos/__init__.py
+++ b/metis_client/dtos/__init__.py
@@ -1,4 +1,4 @@
-"""Data transfer objects"""
+"""All data transfer objects"""
 
 from .auth import MetisAuthCredentialsRequestDTO
 from .base import MetisTimestampsDTO

--- a/metis_client/dtos/collection.py
+++ b/metis_client/dtos/collection.py
@@ -1,4 +1,5 @@
-"""Collections DTO's"""
+"""Collections DTOs"""
+
 import sys
 from typing import Literal, Union
 
@@ -16,7 +17,9 @@ else:  # pragma: no cover
 
 
 MetisCollectionVisibility = Union[
-    Literal["private"], Literal["shared"], Literal["community"]
+    Literal["private"],
+    Literal["shared"],
+    Literal["community"]
 ]
 
 
@@ -30,8 +33,9 @@ class MetisCollectionTypeDTO(MetisTimestampsDTO):
 
 
 class MetisCollectionCommonDTO(TypedDict):
-    "Common fields of collection's DTOs"
+    "Common fields of collection DTOs"
 
+    id: int
     title: str
     typeId: int
     dataSources: NotRequired[Sequence[int]]

--- a/metis_client/dtos/collection.py
+++ b/metis_client/dtos/collection.py
@@ -35,7 +35,7 @@ class MetisCollectionTypeDTO(MetisTimestampsDTO):
 class MetisCollectionCommonDTO(TypedDict):
     "Common fields of collection DTOs"
 
-    id: int
+    id: NotRequired[int]
     title: str
     typeId: int
     dataSources: NotRequired[Sequence[int]]
@@ -45,7 +45,6 @@ class MetisCollectionCommonDTO(TypedDict):
 class MetisCollectionCreateDTO(MetisCollectionCommonDTO):
     "Collection create DTO"
 
-    id: NotRequired[int]
     description: NotRequired[str]
     visibility: NotRequired[MetisCollectionVisibility]
 

--- a/metis_client/dtos/collection.py
+++ b/metis_client/dtos/collection.py
@@ -17,9 +17,7 @@ else:  # pragma: no cover
 
 
 MetisCollectionVisibility = Union[
-    Literal["private"],
-    Literal["shared"],
-    Literal["community"]
+    Literal["private"], Literal["shared"], Literal["community"]
 ]
 
 

--- a/metis_client/dtos/collection.py
+++ b/metis_client/dtos/collection.py
@@ -45,6 +45,7 @@ class MetisCollectionCommonDTO(TypedDict):
 class MetisCollectionCreateDTO(MetisCollectionCommonDTO):
     "Collection create DTO"
 
+    id: NotRequired[int]
     description: NotRequired[str]
     visibility: NotRequired[MetisCollectionVisibility]
 

--- a/metis_client/dtos/datasource.py
+++ b/metis_client/dtos/datasource.py
@@ -18,16 +18,16 @@ else:  # pragma: no cover
 
 
 class DataSourceType(int, Enum):
-    "Data source types"
+
     STRUCTURE = 1
     CALCULATION = 2
     PROPERTY = 3
     WORKFLOW = 4
     PATTERN = 5
+    USER_INPUT = 6
 
 
 class MetisDataSourceDTO(MetisTimestampsDTO):
-    "Data source DTO"
 
     id: int
     parents: Sequence[int]
@@ -43,5 +43,5 @@ class MetisDataSourceDTO(MetisTimestampsDTO):
 
 
 class MetisDataSourceContentOnlyDTO(TypedDict):
-    "Data source content only DTO"
+
     content: str

--- a/metis_client/dtos/datasource.py
+++ b/metis_client/dtos/datasource.py
@@ -18,6 +18,7 @@ else:  # pragma: no cover
 
 
 class DataSourceType(int, Enum):
+    """The basic data types supported"""
 
     STRUCTURE = 1
     CALCULATION = 2
@@ -28,6 +29,7 @@ class DataSourceType(int, Enum):
 
 
 class MetisDataSourceDTO(MetisTimestampsDTO):
+    """A basic data item definition"""
 
     id: int
     parents: Sequence[int]
@@ -43,5 +45,6 @@ class MetisDataSourceDTO(MetisTimestampsDTO):
 
 
 class MetisDataSourceContentOnlyDTO(TypedDict):
+    """Helper definition"""
 
     content: str

--- a/metis_client/dtos/event.py
+++ b/metis_client/dtos/event.py
@@ -1,4 +1,5 @@
-"""Event DTOs"""
+"""SSE DTOs"""
+
 import sys
 from typing import Literal, Union
 
@@ -16,6 +17,7 @@ if sys.version_info < (3, 11):  # pragma: no cover
     from typing_extensions import TypedDict
 else:  # pragma: no cover
     from typing import TypedDict
+
 
 MetisEventType = Literal["calculations", "collections", "datasources", "errors", "pong"]
 

--- a/metis_client/models/event.py
+++ b/metis_client/models/event.py
@@ -1,4 +1,4 @@
-"""Event models"""
+"""SSE models"""
 
 import json
 from dataclasses import dataclass

--- a/metis_client/namespaces/v0_collections.py
+++ b/metis_client/namespaces/v0_collections.py
@@ -50,7 +50,8 @@ class MetisV0CollectionsNamespace(BaseNamespace):
             visibility=opts.get("visibility", "private"),
         )
 
-        if opts.get("id"): payload["id"] = opts["id"] # FIXME???
+        if "id" in opts:
+            payload["id"] = opts["id"]
 
         async with await self._client.request(
             method="PUT",

--- a/metis_client/namespaces/v0_collections.py
+++ b/metis_client/namespaces/v0_collections.py
@@ -27,6 +27,7 @@ else:  # pragma: no cover
 
 class MetisCollectionsCreateKwargs(TypedDict):
     "MetisV0CollectionsNamespace.create kwargs"
+    id: NotRequired[int]
     description: NotRequired[str]
     data_source_ids: NotRequired[Sequence[int]]
     user_ids: NotRequired[Sequence[int]]
@@ -39,8 +40,9 @@ class MetisV0CollectionsNamespace(BaseNamespace):
     async def create_event(
         self, type_id: int, title: str, **opts: Unpack[MetisCollectionsCreateKwargs]
     ) -> MetisRequestIdDTO:
-        "Create collection"
+        "Create or edit the collection"
         payload = MetisCollectionCreateDTO(
+            id=opts.get("id"),
             title=title,
             typeId=type_id,
             description=opts.get("description", ""),
@@ -59,7 +61,7 @@ class MetisV0CollectionsNamespace(BaseNamespace):
     async def create(
         self, type_id: int, title: str, **opts: Unpack[MetisCollectionsCreateKwargs]
     ) -> Optional[MetisCollectionDTO]:
-        "Create collection and wait for result"
+        "Create or edit the collection and wait for the result"
         evt = await act_and_get_result_from_stream(
             self._root.stream.subscribe,
             partial(self.create_event, type_id, title, **opts),

--- a/metis_client/namespaces/v0_collections.py
+++ b/metis_client/namespaces/v0_collections.py
@@ -42,7 +42,6 @@ class MetisV0CollectionsNamespace(BaseNamespace):
     ) -> MetisRequestIdDTO:
         "Create or edit the collection"
         payload = MetisCollectionCreateDTO(
-            id=opts.get("id"),
             title=title,
             typeId=type_id,
             description=opts.get("description", ""),
@@ -50,6 +49,9 @@ class MetisV0CollectionsNamespace(BaseNamespace):
             users=opts.get("user_ids", []),
             visibility=opts.get("visibility", "private"),
         )
+
+        if opts.get("id"): payload["id"] = opts["id"] # FIXME???
+
         async with await self._client.request(
             method="PUT",
             url=self._base_url,


### PR DESCRIPTION
@knopki `client.v0.collections.create()` also supports editing the existing collections (the `id` has to be supplied), see https://github.com/basf/metis-bff/blob/f6f73257d6f2603496118676969663e4d6e4deaa/routes/%5Bversion%5D/collections/_helpers.js#L65

However here is a caveat: 3 kwargs `typeId`,  `dataSources`, and `users` are mapped onto `type_id`, `data_source_ids`, and `user_ids` (note camel case vs. snake case) which prevents me from doing `client.v0.collections.create(**dict(metis_collection_changed))`. I assume, the `MetisCollectionCreateDTO` should be upgraded for that, right?