### PR TITLE
fix(MetisAPI): match *data_source_ids* to *data_sources*

### DIFF
--- a/metis_client/namespaces/v0_collections.py
+++ b/metis_client/namespaces/v0_collections.py
@@ -20,7 +20,7 @@ class MetisCollectionsCreateKwargs(TypedDict):
     "MetisV0CollectionsNamespace.create kwargs"
     id: NotRequired[int]
     description: NotRequired[str]
-    data_source_ids: NotRequired[Sequence[int]]
+    data_sources: NotRequired[Sequence[int]]
     user_ids: NotRequired[Sequence[int]]
     visibility: NotRequired[MetisCollectionVisibility]
 
@@ -36,7 +36,7 @@ class MetisV0CollectionsNamespace(BaseNamespace):
             title=title,
             type_id=type_id,
             description=opts.get("description", ""),
-            data_sources=opts.get("data_source_ids", []),
+            data_sources=opts.get("data_sources", []),
             users=opts.get("user_ids", []),
             visibility=opts.get("visibility", "private"),
         )

--- a/tests/namespaces/test_v0_collections.py
+++ b/tests/namespaces/test_v0_collections.py
@@ -217,7 +217,7 @@ async def test_create_collection(
         "type_id": type_id,
         "title": PATH_C_PUT_PAYLOAD["title"],
         "description": PATH_C_PUT_PAYLOAD["description"],
-        "data_source_ids": PATH_C_PUT_PAYLOAD["data_sources"],
+        "data_sources": PATH_C_PUT_PAYLOAD["data_sources"],
         "user_ids": PATH_C_PUT_PAYLOAD["users"],
         "visibility": PATH_C_PUT_PAYLOAD["visibility"],
     }


### PR DESCRIPTION
Finally with this we should be able to do `client.v0.collections.create(**metis_collection_changed)`