### PR TITLE
fix(MetisAPI): ability to run sync API in async runtime

### DIFF
--- a/metis_client/exc.py
+++ b/metis_client/exc.py
@@ -53,3 +53,7 @@ class MetisAuthenticationException(MetisError):
 
 class MetisQuotaException(MetisError):
     """This is raised when quota excided."""
+
+
+class MetisAsyncRuntimeWarning(UserWarning):
+    """Use of sync API in async runtime"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ requires-python = ">=3.8"
 dependencies = [
     "aiohttp >= 3.7.4",
     "aiohttp-sse-client >= 0.2.1",
-    "asgiref >= 3.5.2",
     "camel-converter >= 3",
     "typing-extensions >= 4.2.0; python_version < '3.11'",
     "yarl >= 1.6.3",
@@ -115,6 +114,9 @@ max-line-length = 88
 output-format = "colorized"
 reports = "no"
 score = "no"
+
+[tool.pylint.typecheck]
+signature-mutators = "metis_client.metis.to_sync_with_metis_client"
 
 [tool.pylint.similarities]
 min-similarity-lines = 8

--- a/tests/test_metis.py
+++ b/tests/test_metis.py
@@ -1,8 +1,35 @@
 "Test MetisAPI"
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from yarl import URL
 
 from metis_client import MetisAPI, MetisNoAuth
+from metis_client.exc import (
+    MetisAsyncRuntimeWarning,
+    MetisConnectionException,
+    MetisException,
+)
+
+
+async def create_app() -> web.Application:
+    "Create web application"
+    app = web.Application()
+    return app
+
+
+@pytest.fixture
+async def aiohttp_client(aiohttp_client) -> TestClient:
+    "Create test client"
+    app = await create_app()
+    return await aiohttp_client(TestServer(app))
+
+
+@pytest.fixture
+def base_url(aiohttp_client: TestClient) -> URL:
+    "Return base url"
+    return aiohttp_client.make_url("")
 
 
 @pytest.mark.parametrize(
@@ -19,8 +46,24 @@ from metis_client import MetisAPI, MetisNoAuth
         (1, 1, 1),
     ],
 )
-async def test_sync_ns_timeout(default_timeout, timeout, result):
+async def test_sync_ns_timeout(base_url: URL, default_timeout, timeout, result):
     "Test timeout guessing method"
-    client = MetisAPI("/", auth=MetisNoAuth(), timeout=default_timeout)
+    client = MetisAPI(base_url, auth=MetisNoAuth(), timeout=default_timeout)
     # pylint: disable=protected-access
     assert client.v0._get_timeout(timeout) == result
+
+
+async def test_sync_in_async_runtime(base_url: URL):
+    """
+    Use sync API in an async runtime.
+    It's impossible to connect to the test fake server
+    because of runtime block by synchronous function call.
+    So, we check that:
+     - RuntimeError is absent (asyncio.run() cannot be called from a running event loop)
+     - MetisAsyncRuntimeWarning is present about misuse of API
+     - timeout exception is present
+    """
+    client = MetisAPI(base_url, auth=MetisNoAuth(), timeout=0.0001)
+    with pytest.warns(MetisAsyncRuntimeWarning):
+        with pytest.raises((MetisConnectionException, MetisException)):  # noqa: B908
+            client.v0.auth.whoami()


### PR DESCRIPTION
Closes #46 
Detect running event loop. If running loop is present, then run coroutine in a blocking thread.
Also, throw a warning about API misuse.
`asgiref` dependency is thrown away.